### PR TITLE
feat(vue): updated renderNoResult examples in vue-playground

### DIFF
--- a/stories/MultiDropdownListWithRenderNoResultsSlot.vue
+++ b/stories/MultiDropdownListWithRenderNoResultsSlot.vue
@@ -1,0 +1,69 @@
+<template>
+  <ReactiveBase
+      app="good-books-ds"
+      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+      :enableAppbase="true"
+  >
+    <div class="row">
+      <div class="col">
+        <MultiDropdownList
+          componentId="BookSensor"
+          data-field="original_series.keyword"
+          :renderNoResults="renderNoResults"
+        />
+      </div>
+
+      <div class="col">
+        <SelectedFilters/>
+        <ReactiveList
+          componentId="SearchResult"
+          data-field="original_title.keyword"
+          class="result-list-container"
+          :pagination="true"
+          :from="0"
+          :size="5"
+          :react="{and: ['BookSensor']}"
+        >
+          <div slot="renderItem" slot-scope="{ item }">
+            <div class="flex book-content" key="item._id">
+              <img :src="item.image" alt="Book Cover" class="book-image">
+              <div class="flex column justify-center ml20">
+                <div class="book-header">{{ item.original_title }}</div>
+                <div class="flex column justify-space-between">
+                  <div>
+                    <div>
+                      by
+                      <span class="authors-list">{{ item.authors }}</span>
+                    </div>
+                    <div class="ratings-list flex align-center">
+                      <span class="stars">
+                        <span
+                          v-for="(item, index) in Array(item.average_rating_rounded).fill('x').slice(0, item.average_rating_rounded)"
+                          :key="index + Date.now()"
+                        >
+                          <i class="fas fa-star"/>
+                        </span>
+                      </span>
+                      <span class="avg-rating">({{item.average_rating}} avg)</span>
+                    </div>
+                  </div>
+                  <span class="pub-year">Pub {{item.original_publication_year}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ReactiveList>
+      </div>
+    </div>
+  </ReactiveBase>
+</template>
+<script>
+export default {
+    name: 'MultiDropdownListWithRenderNoResultsSlot',
+    methods: {
+        renderNoResults() {
+            return 'No Results';
+        }
+    }
+};
+</script>

--- a/stories/MultiListWithRenderNoResultsSlot.vue
+++ b/stories/MultiListWithRenderNoResultsSlot.vue
@@ -1,0 +1,69 @@
+<template>
+  <ReactiveBase
+      app="good-books-ds"
+      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+      :enableAppbase="true"
+  >
+    <div class="row">
+      <div class="col">
+        <MultiList
+          componentId="BookSensor"
+          data-field="authors.keyword"
+          :renderNoResults="renderNoResults"
+        />
+      </div>
+
+      <div class="col">
+        <SelectedFilters/>
+        <ReactiveList
+          componentId="SearchResult"
+          data-field="original_title.keyword"
+          class="result-list-container"
+          :pagination="true"
+          :from="0"
+          :size="5"
+          :react="{and: ['BookSensor']}"
+        >
+          <div slot="renderItem" slot-scope="{ item }">
+            <div class="flex book-content" key="item._id">
+              <img :src="item.image" alt="Book Cover" class="book-image">
+              <div class="flex column justify-center ml20">
+                <div class="book-header">{{ item.original_title }}</div>
+                <div class="flex column justify-space-between">
+                  <div>
+                    <div>
+                      by
+                      <span class="authors-list">{{ item.authors }}</span>
+                    </div>
+                    <div class="ratings-list flex align-center">
+                      <span class="stars">
+                        <span
+                          v-for="(item, index) in Array(item.average_rating_rounded).fill('x').slice(0, item.average_rating_rounded)"
+                          :key="index + Date.now()"
+                        >
+                          <i class="fas fa-star"/>
+                        </span>
+                      </span>
+                      <span class="avg-rating">({{item.average_rating}} avg)</span>
+                    </div>
+                  </div>
+                  <span class="pub-year">Pub {{item.original_publication_year}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ReactiveList>
+      </div>
+    </div>
+  </ReactiveBase>
+</template>
+<script>
+export default {
+    name: 'MultiListWithRenderNoResultsSlot',
+    methods: {
+        renderNoResults() {
+            return 'No Results';
+        }
+    }
+};
+</script>

--- a/stories/SingleDropdownListWithRenderNoResultsSlot.vue
+++ b/stories/SingleDropdownListWithRenderNoResultsSlot.vue
@@ -1,0 +1,70 @@
+<template>
+  <ReactiveBase
+      app="good-books-ds"
+      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+      :enableAppbase="true"
+  >
+    <div class="row">
+      <div class="col">
+        <SingleDropdownList
+          componentId="BookSensor"
+          data-field="original_series.keyword"
+          :renderNoResults="renderNoResults"
+        />
+      </div>
+
+      <div class="col">
+        <SelectedFilters/>
+        <ReactiveList
+          componentId="SearchResult"
+          data-field="original_title.keyword"
+          class="result-list-container"
+          :pagination="true"
+          :from="0"
+          :size="5"
+          :react="{and: ['BookSensor']}"
+        >
+          <div slot="renderItem" slot-scope="{ item }">
+            <div class="flex book-content" key="item._id">
+              <img :src="item.image" alt="Book Cover" class="book-image">
+              <div class="flex column justify-center ml20">
+                <div class="book-header">{{ item.original_title }}</div>
+                <div class="book-header" v-html="item.original_title"></div>
+                <div class="flex column justify-space-between">
+                  <div>
+                    <div>
+                      by
+                      <span class="authors-list">{{ item.authors }}</span>
+                    </div>
+                    <div class="ratings-list flex align-center">
+                      <span class="stars">
+                        <span
+                          v-for="(item, index) in Array(item.average_rating_rounded).fill('x').slice(0, item.average_rating_rounded)"
+                          :key="index + Date.now()"
+                        >
+                          <i class="fas fa-star"/>
+                        </span>
+                      </span>
+                      <span class="avg-rating">({{item.average_rating}} avg)</span>
+                    </div>
+                  </div>
+                  <span class="pub-year">Pub {{item.original_publication_year}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ReactiveList>
+      </div>
+    </div>
+  </ReactiveBase>
+</template>
+<script>
+export default {
+    name: 'SingleDropdownListWithRenderNoResultsSlot',
+    methods: {
+        renderNoResults() {
+            return 'No Results';
+        }
+    }
+};
+</script>

--- a/stories/SingleListWithRenderNoResultsSlot.vue
+++ b/stories/SingleListWithRenderNoResultsSlot.vue
@@ -1,0 +1,69 @@
+<template>
+  <ReactiveBase
+      app="good-books-ds"
+      url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@arc-cluster-appbase-demo-6pjy6z.searchbase.io"
+      :enableAppbase="true"
+  >
+    <div class="row">
+      <div class="col">
+        <SingleList
+          componentId="BookSensor"
+          data-field="original_series.keyword"
+          :renderNoResults="renderNoResults"
+        />
+      </div>
+
+      <div class="col">
+        <selected-filters/>
+        <ReactiveList
+          componentId="SearchResult"
+          data-field="original_title.keyword"
+          class="result-list-container"
+          :pagination="true"
+          :from="0"
+          :size="5"
+          :react="{and: ['BookSensor']}"
+        >
+          <div slot="renderItem" slot-scope="{ item }">
+            <div class="flex book-content" key="item._id">
+              <img :src="item.image" alt="Book Cover" class="book-image">
+              <div class="flex column justify-center ml20">
+                <div class="book-header">{{ item.original_title }}</div>
+                <div class="flex column justify-space-between">
+                  <div>
+                    <div>
+                      by
+                      <span class="authors-list">{{ item.authors }}</span>
+                    </div>
+                    <div class="ratings-list flex align-center">
+                      <span class="stars">
+                        <span
+                          v-for="(item, index) in Array(item.average_rating_rounded).fill('x').slice(0, item.average_rating_rounded)"
+                          :key="index + Date.now()"
+                        >
+                          <i class="fas fa-star"/>
+                        </span>
+                      </span>
+                      <span class="avg-rating">({{item.average_rating}} avg)</span>
+                    </div>
+                  </div>
+                  <span class="pub-year">Pub {{item.original_publication_year}}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ReactiveList>
+      </div>
+    </div>
+  </ReactiveBase>
+</template>
+<script>
+export default {
+    name: 'SingleListWithRenderNoResultsSlot',
+    methods: {
+        renderNoResults() {
+            return 'No Results';
+        }
+    }
+};
+</script>

--- a/stories/index.js
+++ b/stories/index.js
@@ -30,6 +30,10 @@ import MultiListWithRenderSlot from './MultiListWithRenderSlot';
 import SingleDropdownListWithRenderSlot from './SingleDropdownListWithRenderSlot';
 import MultiDropdownListWithRenderSlot from './MultiDropdownListWithRenderSlot';
 import DataSearchWithRenderQuerySuggestionsSlot from './DataSearchWithRenderQuerySuggestionsSlot';
+import SingleListWithRenderNoResultsSlot from "./SingleListWithRenderNoResultsSlot.vue";
+import SingleDropdownListWithRenderNoResultsSlot from "./SingleDropdownListWithRenderNoResultsSlot";
+import MultiListWithRenderNoResultsSlot from "./MultiListWithRenderNoResultsSlot.vue";
+import MultiDropdownListWithRenderNoResultsSlot from "./MultiDropdownListWithRenderNoResultsSlot";
 import './styles.css';
 
 // README
@@ -267,10 +271,14 @@ storiesOf('List Components/SingleList', module)
 	props: sortBy(),
     template: '<base-single-list :subProps="{ sortBy }"/>',
   }))
-	.add('with render slot', () => ({
-		components: { SingleListWithRenderSlot },
-		template: '<single-list-with-render-slot />'
-	}));
+  .add('with render slot', () => ({
+	components: { SingleListWithRenderSlot },
+	template: '<single-list-with-render-slot />'
+  }))
+  .add('with renderNoResults', () => ({
+	components: { SingleListWithRenderNoResultsSlot },
+	template: '<single-list-with-render-no-results-slot />'
+  }));
 
 storiesOf('List Components/MulitList', module)
 	.addParameters({
@@ -334,10 +342,14 @@ storiesOf('List Components/MulitList', module)
 		props: sortBy(),
     template: '<base-multi-list :subProps="{ sortBy }"/>',
   }))
-	.add('with render slot', () => ({
-		components: { MultiListWithRenderSlot },
-		template: '<multi-list-with-render-slot />'
-	}));
+  .add('with render slot', () => ({
+	components: { MultiListWithRenderSlot },
+	template: '<multi-list-with-render-slot />'
+  }))
+  .add('with renderNoResults', () => ({
+	components: { MultiListWithRenderNoResultsSlot },
+	template: '<multi-list-with-render-no-results-slot />'
+  }));
 
 storiesOf('List Components/SingleDropdownList', module)
 	.addParameters({
@@ -413,6 +425,10 @@ storiesOf('List Components/SingleDropdownList', module)
 	.add('with render slot', () => ({
 		components: { SingleDropdownListWithRenderSlot },
 		template: '<single-dropdown-list-with-render-slot />'
+	}))
+	.add('with renderNoResults', () => ({
+		components: { SingleDropdownListWithRenderNoResultsSlot },
+		template: '<single-dropdown-list-with-render-no-results-slot />'
 	}));
 
 
@@ -499,6 +515,10 @@ storiesOf('List Components/MultiDropdownList ', module)
 	.add('with render slot', () => ({
 		components: { MultiDropdownListWithRenderSlot },
 		template: '<multi-dropdown-list-with-render-slot />'
+	}))
+	.add('with renderNoResults', () => ({
+		components: { MultiDropdownListWithRenderNoResultsSlot },
+		template: '<multi-dropdown-list-with-render-no-results-slot />'
 	}));
 
 storiesOf('Search Components/DataSearch', module)


### PR DESCRIPTION
- examples added for renderNoResults prop in the list components.
- please go through the following PR for reference - https://github.com/appbaseio/reactivesearch/pull/1599