### PR TITLE
feat(vue): storybook example added for single list with enableStrictSelction prop usage

### DIFF
--- a/stories/index.js
+++ b/stories/index.js
@@ -303,6 +303,11 @@ storiesOf('List Components/SingleList', module)
   .add('with renderNoResults', () => ({
 	components: { SingleListWithRenderNoResultsSlot },
 	template: '<single-list-with-render-no-results-slot />'
+  }))
+  .add('with enableStrictSelection', () => ({
+    components: { BaseSingleList },
+	props: getKnob('enableStrictSelection', true),
+    template: '<base-single-list :subProps="{ enableStrictSelection }"/>',
   }));
 
 storiesOf('List Components/MulitList', module)


### PR DESCRIPTION
- Example added in ReactiveSearch vue stories for `SingleList` to demonstrate the usage of `enableStrictSelection` prop
- Please refer to the following PR for further reference - https://github.com/appbaseio/reactivesearch/pull/1708