### PR TITLE
Fix(vue): missing/broken stories

### DIFF
--- a/stories/BaseRangeInput.vue
+++ b/stories/BaseRangeInput.vue
@@ -14,10 +14,6 @@
                             start: 3000,
                             end: 50000,
                         }"
-                        :rangeLabels="{
-                            start: '3K',
-                            end: '50K',
-                        }"
                         :componentStyle="{
                             margin: '10px'
                         }"

--- a/stories/BaseRangeSlider.vue
+++ b/stories/BaseRangeSlider.vue
@@ -13,10 +13,6 @@
             start: 3000,
             end: 50000
           }"
-          :rangeLabels="{
-            start: '3K',
-            end: '50K'
-          }"
           v-bind="subProps"
           v-on="subEvents"
         />

--- a/stories/BaseReactiveListCardLayout.vue
+++ b/stories/BaseReactiveListCardLayout.vue
@@ -1,0 +1,68 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<ReactiveList
+			componentId="SearchResult"
+			data-field="original_title.keyword"
+			class="result-list-container"
+			:from="0"
+			:size="5"
+			:react="{ and: ['BookSensor'] }"
+			v-bind="subProps"
+			v-on="subEvents"
+		>
+			<div slot="render" slot-scope="{ data }">
+				<ResultCardsWrapper>
+					<ResultCard v-bind:key="result._id" :id="result._id" v-for="result in data">
+						<ResultCardImage :src="result.image" />
+						<ResultCardTitle>
+							{{ result.original_title }}
+						</ResultCardTitle>
+						<ResultCardDescription>
+							<div class="flex column justify-space-between">
+								<div>
+									<div>
+										by
+										<span class="authors-list">{{ result.authors }}</span>
+									</div>
+									<div class="ratings-list flex align-center">
+										<span class="stars">
+											<span
+												v-for="(result, index) in Array(
+													result.average_rating_rounded,
+												)
+													.fill('x')
+													.slice(0, result.average_rating_rounded)"
+												:key="index + Date.now()"
+											>
+												<i class="fas fa-star" />
+											</span>
+										</span>
+										<span class="avg-rating"
+											>({{ result.average_rating }} avg)</span
+										>
+									</div>
+								</div>
+								<span class="pub-year"
+									>Pub {{ result.original_publication_year }}</span
+								>
+							</div>
+						</ResultCardDescription>
+					</ResultCard>
+				</ResultCardsWrapper>
+			</div>
+		</ReactiveList>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'BaseReactiveListCardLayout',
+	props: {
+		subProps: Object,
+		subEvents: Object,
+	},
+};
+</script>

--- a/stories/MultiDropdownListWithRenderItemSlot.vue
+++ b/stories/MultiDropdownListWithRenderItemSlot.vue
@@ -1,0 +1,80 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<div class="row">
+			<div class="col">
+				<MultiDropdownList
+					:showSearch="false"
+					componentId="BookSensor"
+					data-field="original_series.keyword"
+				>
+					<div slot="renderItem" slot-scope="{ label, count }">
+						{{ label }}
+						<span :style="{ marginLeft: 5, color: 'dodgerblue' }">
+							{{ count }}
+						</span>
+					</div>
+				</MultiDropdownList>
+			</div>
+
+			<div class="col">
+				<SelectedFilters />
+				<ReactiveList
+					componentId="SearchResult"
+					data-field="original_title.keyword"
+					class="result-list-container"
+					:pagination="true"
+					:from="0"
+					:size="5"
+					:react="{ and: ['BookSensor'] }"
+				>
+					<div slot="renderItem" slot-scope="{ item }">
+						<div class="flex book-content" key="item._id">
+							<img :src="item.image" alt="Book Cover" class="book-image" />
+							<div class="flex column justify-center ml20">
+								<div class="book-header">{{ item.original_title }}</div>
+								<div class="book-header" v-html="item.original_title"></div>
+								<div class="flex column justify-space-between">
+									<div>
+										<div>
+											by
+											<span class="authors-list">{{ item.authors }}</span>
+										</div>
+										<div class="ratings-list flex align-center">
+											<span class="stars">
+												<span
+													v-for="(item, index) in Array(
+														item.average_rating_rounded,
+													)
+														.fill('x')
+														.slice(0, item.average_rating_rounded)"
+													:key="index + Date.now()"
+												>
+													<i class="fas fa-star" />
+												</span>
+											</span>
+											<span class="avg-rating"
+												>({{ item.average_rating }} avg)</span
+											>
+										</div>
+									</div>
+									<span class="pub-year"
+										>Pub {{ item.original_publication_year }}</span
+									>
+								</div>
+							</div>
+						</div>
+					</div>
+				</ReactiveList>
+			</div>
+		</div>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'MultiDropdownListWithRenderItemSlot',
+};
+</script>

--- a/stories/MultiDropdownListWithRenderNoResultsSlot.vue
+++ b/stories/MultiDropdownListWithRenderNoResultsSlot.vue
@@ -8,7 +8,7 @@
       <div class="col">
         <MultiDropdownList
           componentId="BookSensor"
-          data-field="original_series.keyword"
+          data-field="test.keyword"
           :renderNoResults="renderNoResults"
         />
       </div>

--- a/stories/MultiListWithRenderItemSlot.vue
+++ b/stories/MultiListWithRenderItemSlot.vue
@@ -1,0 +1,79 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<div class="row">
+			<div class="col">
+				<MultiList
+					:showSearch="false"
+					componentId="BookSensor"
+					data-field="original_series.keyword"
+				>
+					<div slot="renderItem" slot-scope="{ label, count }">
+						{{ label }}
+						<span :style="{ marginLeft: 5, color: 'dodgerblue' }">
+							{{ count }}
+						</span>
+					</div>
+				</MultiList>
+			</div>
+
+			<div class="col">
+				<SelectedFilters />
+				<ReactiveList
+					componentId="SearchResult"
+					data-field="original_title.keyword"
+					class="result-list-container"
+					:pagination="true"
+					:from="0"
+					:size="5"
+					:react="{ and: ['BookSensor'] }"
+				>
+					<div slot="renderItem" slot-scope="{ item }">
+						<div class="flex book-content" key="item._id">
+							<img :src="item.image" alt="Book Cover" class="book-image" />
+							<div class="flex column justify-center ml20">
+								<div class="book-header">{{ item.original_title }}</div>
+								<div class="flex column justify-space-between">
+									<div>
+										<div>
+											by
+											<span class="authors-list">{{ item.authors }}</span>
+										</div>
+										<div class="ratings-list flex align-center">
+											<span class="stars">
+												<span
+													v-for="(item, index) in Array(
+														item.average_rating_rounded,
+													)
+														.fill('x')
+														.slice(0, item.average_rating_rounded)"
+													:key="index + Date.now()"
+												>
+													<i class="fas fa-star" />
+												</span>
+											</span>
+											<span class="avg-rating"
+												>({{ item.average_rating }} avg)</span
+											>
+										</div>
+									</div>
+									<span class="pub-year"
+										>Pub {{ item.original_publication_year }}</span
+									>
+								</div>
+							</div>
+						</div>
+					</div>
+				</ReactiveList>
+			</div>
+		</div>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'MultiListWithRenderItemSlot',
+};
+</script>

--- a/stories/MultiListWithRenderNoResultsSlot.vue
+++ b/stories/MultiListWithRenderNoResultsSlot.vue
@@ -8,7 +8,7 @@
       <div class="col">
         <MultiList
           componentId="BookSensor"
-          data-field="authors.keyword"
+          data-field="test.keyword"
           :renderNoResults="renderNoResults"
         />
       </div>
@@ -62,7 +62,7 @@ export default {
     name: 'MultiListWithRenderNoResultsSlot',
     methods: {
         renderNoResults() {
-            return 'No Results';
+            return 'No Results found';
         }
     }
 };

--- a/stories/ReactiveListWithCustomResultStatsSlot.vue
+++ b/stories/ReactiveListWithCustomResultStatsSlot.vue
@@ -1,0 +1,63 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<ReactiveList
+			componentId="SearchResult"
+			data-field="original_title.keyword"
+			class="result-list-container"
+			:from="0"
+			:size="10"
+			:react="{ and: ['BookSensor'] }"
+			v-bind="subProps"
+			v-on="subEvents"
+			><div slot="renderResultStats" slot-scope="{ numberOfResults, time, displayedResults }">
+				Custom: Showing {{ displayedResults }} of total {{ numberOfResults }} in {{ time }} ms
+			</div>
+
+			<div slot="renderItem" slot-scope="{ item }">
+				<div class="flex book-content" key="item._id">
+					<img :src="item.image" alt="Book Cover" class="book-image" />
+					<div class="flex column justify-center ml20">
+						<div class="book-header">{{ item.original_title }}</div>
+						<div class="flex column justify-space-between">
+							<div>
+								<div>
+									by
+									<span class="authors-list">{{ item.authors }}</span>
+								</div>
+								<div class="ratings-list flex align-center">
+									<span class="stars">
+										<span
+											v-for="(item, index) in Array(
+												item.average_rating_rounded,
+											)
+												.fill('x')
+												.slice(0, item.average_rating_rounded)"
+											:key="index + Date.now()"
+										>
+											<i class="fas fa-star" />
+										</span>
+									</span>
+									<span class="avg-rating">({{ item.average_rating }} avg)</span>
+								</div>
+							</div>
+							<span class="pub-year">Pub {{ item.original_publication_year }}</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</ReactiveList>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'ReactiveListWithCustomResultStatsSlot',
+	props: {
+		subProps: Object,
+		subEvents: Object,
+	},
+};
+</script>

--- a/stories/ReactiveListWithNoResultsSlot.vue
+++ b/stories/ReactiveListWithNoResultsSlot.vue
@@ -1,0 +1,60 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<ReactiveList
+			componentId="SearchResult"
+			data-field="authors.keyword"
+			class="result-list-container"
+			:from="0"
+			:size="0"
+			:react="{ and: ['BookSensor'] }"
+			v-bind="subProps"
+			v-on="subEvents"
+		>
+			<div slot="renderItem" slot-scope="{ item }">
+				<div class="flex book-content" key="item._id">
+					<img :src="item.image" alt="Book Cover" class="book-image" />
+					<div class="flex column justify-center ml20">
+						<div class="book-header">{{ item.original_title }}</div>
+						<div class="flex column justify-space-between">
+							<div>
+								<div>
+									by
+									<span class="authors-list">{{ item.authors }}</span>
+								</div>
+								<div class="ratings-list flex align-center">
+									<span class="stars">
+										<span
+											v-for="(item, index) in Array(
+												item.average_rating_rounded,
+											)
+												.fill('x')
+												.slice(0, item.average_rating_rounded)"
+											:key="index + Date.now()"
+										>
+											<i class="fas fa-star" />
+										</span>
+									</span>
+									<span class="avg-rating">({{ item.average_rating }} avg)</span>
+								</div>
+							</div>
+							<span class="pub-year">Pub {{ item.original_publication_year }}</span>
+						</div>
+					</div>
+				</div>
+			</div>
+		</ReactiveList>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'ReactiveListWithNoResultsSlot',
+	props: {
+		subProps: Object,
+		subEvents: Object,
+	},
+};
+</script>

--- a/stories/SingleDropdownListWithRenderItemSlot.vue
+++ b/stories/SingleDropdownListWithRenderItemSlot.vue
@@ -1,0 +1,80 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<div class="row">
+			<div class="col">
+				<SingleDropdownList
+					:showSearch="false"
+					componentId="BookSensor"
+					data-field="original_series.keyword"
+				>
+					<div slot="renderItem" slot-scope="{ label, count }">
+						{{ label }}
+						<span :style="{ marginLeft: 5, color: 'dodgerblue' }">
+							{{ count }}
+						</span>
+					</div></SingleDropdownList
+				>
+			</div>
+
+			<div class="col">
+				<SelectedFilters />
+				<ReactiveList
+					componentId="SearchResult"
+					data-field="original_title.keyword"
+					class="result-list-container"
+					:pagination="true"
+					:from="0"
+					:size="5"
+					:react="{ and: ['BookSensor'] }"
+				>
+					<div slot="renderItem" slot-scope="{ item }">
+						<div class="flex book-content" key="item._id">
+							<img :src="item.image" alt="Book Cover" class="book-image" />
+							<div class="flex column justify-center ml20">
+								<div class="book-header">{{ item.original_title }}</div>
+								<div class="book-header" v-html="item.original_title"></div>
+								<div class="flex column justify-space-between">
+									<div>
+										<div>
+											by
+											<span class="authors-list">{{ item.authors }}</span>
+										</div>
+										<div class="ratings-list flex align-center">
+											<span class="stars">
+												<span
+													v-for="(item, index) in Array(
+														item.average_rating_rounded,
+													)
+														.fill('x')
+														.slice(0, item.average_rating_rounded)"
+													:key="index + Date.now()"
+												>
+													<i class="fas fa-star" />
+												</span>
+											</span>
+											<span class="avg-rating"
+												>({{ item.average_rating }} avg)</span
+											>
+										</div>
+									</div>
+									<span class="pub-year"
+										>Pub {{ item.original_publication_year }}</span
+									>
+								</div>
+							</div>
+						</div>
+					</div>
+				</ReactiveList>
+			</div>
+		</div>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'SingleDropdownListWithRenderItemSlot',
+};
+</script>

--- a/stories/SingleDropdownListWithRenderNoResultsSlot.vue
+++ b/stories/SingleDropdownListWithRenderNoResultsSlot.vue
@@ -8,7 +8,7 @@
       <div class="col">
         <SingleDropdownList
           componentId="BookSensor"
-          data-field="original_series.keyword"
+          data-field="test.keyword"
           :renderNoResults="renderNoResults"
         />
       </div>

--- a/stories/SingleListWithRenderItemSlot.vue
+++ b/stories/SingleListWithRenderItemSlot.vue
@@ -1,0 +1,79 @@
+<template>
+	<ReactiveBase
+		app="good-books-ds"
+		url="https://a03a1cb71321:75b6603d-9456-4a5a-af6b-a487b309eb61@appbase-demo-ansible-abxiydt-arc.searchbase.io"
+		:enableAppbase="true"
+	>
+		<div class="row">
+			<div class="col">
+				<SingleList
+					:showSearch="false"
+					componentId="BookSensor"
+					data-field="original_series.keyword"
+				>
+					<div slot="renderItem" slot-scope="{ label, count }">
+						{{ label }}
+						<span :style="{ marginLeft: 5, color: 'dodgerblue' }">
+							{{ count }}
+						</span>
+					</div>
+				</SingleList>
+			</div>
+
+			<div class="col">
+				<selected-filters />
+				<ReactiveList
+					componentId="SearchResult"
+					data-field="original_title.keyword"
+					class="result-list-container"
+					:pagination="true"
+					:from="0"
+					:size="5"
+					:react="{ and: ['BookSensor'] }"
+				>
+					<div slot="renderItem" slot-scope="{ item }">
+						<div class="flex book-content" key="item._id">
+							<img :src="item.image" alt="Book Cover" class="book-image" />
+							<div class="flex column justify-center ml20">
+								<div class="book-header">{{ item.original_title }}</div>
+								<div class="flex column justify-space-between">
+									<div>
+										<div>
+											by
+											<span class="authors-list">{{ item.authors }}</span>
+										</div>
+										<div class="ratings-list flex align-center">
+											<span class="stars">
+												<span
+													v-for="(item, index) in Array(
+														item.average_rating_rounded,
+													)
+														.fill('x')
+														.slice(0, item.average_rating_rounded)"
+													:key="index + Date.now()"
+												>
+													<i class="fas fa-star" />
+												</span>
+											</span>
+											<span class="avg-rating"
+												>({{ item.average_rating }} avg)</span
+											>
+										</div>
+									</div>
+									<span class="pub-year"
+										>Pub {{ item.original_publication_year }}</span
+									>
+								</div>
+							</div>
+						</div>
+					</div>
+				</ReactiveList>
+			</div>
+		</div>
+	</ReactiveBase>
+</template>
+<script>
+export default {
+	name: 'SingleListWithRenderItemSlot',
+};
+</script>

--- a/stories/SingleListWithRenderNoResultsSlot.vue
+++ b/stories/SingleListWithRenderNoResultsSlot.vue
@@ -8,7 +8,7 @@
       <div class="col">
         <SingleList
           componentId="BookSensor"
-          data-field="original_series.keyword"
+          data-field="test.keyword"
           :renderNoResults="renderNoResults"
         />
       </div>
@@ -62,7 +62,7 @@ export default {
     name: 'SingleListWithRenderNoResultsSlot',
     methods: {
         renderNoResults() {
-            return 'No Results';
+            return 'No Results Found!';
         }
     }
 };

--- a/stories/index.js
+++ b/stories/index.js
@@ -450,6 +450,11 @@ storiesOf('List Components/SingleDropdownList', module)
 		props: showCount(false),
     template: '<base-single-dropdown-list :subProps="{ showCount, showFilter: false}"/>',
   }))
+    .add('with search', () => ({
+		components: { BaseSingleDropdownList },
+		props: showSearch(false),
+    template: '<base-single-dropdown-list :subProps="{ showSearch, showFilter: false}"/>',
+  }))  
     .add('with defaultValue', () => ({
 		props: defaultValue('Artemis Fowl'),
     components: { BaseSingleDropdownList },

--- a/stories/index.js
+++ b/stories/index.js
@@ -219,6 +219,15 @@ storiesOf('Range Components/RangeSlider', module)
 		props: defaultValue({ start: 3000, end: 9000 }),
     template: '<base-range-slider :subProps="{ defaultValue, showFilter: false}"/>',
 	}))
+   .add('with range Labels', () => ({
+	components: { BaseRangeSlider },
+	   props: rangeLabels(
+		   {
+                start: '3K',
+				end: '50K',
+		}),
+    template: '<base-range-slider :subProps="{ rangeLabels }"/>',
+	}))	
 
 storiesOf('Range Components/RangeInput', module)
 	.addParameters({
@@ -249,7 +258,7 @@ storiesOf('Range Components/RangeInput', module)
 				end: '50K',
 		}),
     template: '<base-range-input :subProps="{ rangeLabels }"/>',
-	}))	
+	}))
 
 storiesOf('Range Components/DynamicRangeSlider', module)
 	.addParameters({

--- a/stories/index.js
+++ b/stories/index.js
@@ -114,6 +114,7 @@ const showSearch = (value = true) => getKnob('showSearch', value);
 const showClear = (value = true) => getKnob('showClear', value);
 const highlight = (value = true) => getKnob('highlight', value);
 const showCheckbox = (value = true) => getKnob('showCheckbox', value);
+const rangeLabels = (value) => getKnob('rangeLabels', value);
 
 function removeFirstLine(str, number = 12) {
   while (number--) {
@@ -209,7 +210,7 @@ storiesOf('Range Components/RangeSlider', module)
     template: '<base-range-slider :subProps="{ showFilter: false }"/>',
   }))
   .add('with title', () => ({
-		props: titleKnob('RangeSlider: Ratings'),
+	props: titleKnob('RangeSlider: Ratings'),
     components: { BaseRangeSlider },
     template: '<base-range-slider :subProps="{ title}"/>',
   }))
@@ -240,6 +241,15 @@ storiesOf('Range Components/RangeInput', module)
 	props: defaultValue({ start: 3000, end: 9000 }),
     template: '<base-range-input :subProps="{ defaultValue, showFilter: false}"/>',
 	}))
+   .add('with range Labels', () => ({
+	components: { BaseRangeInput },
+	   props: rangeLabels(
+		   {
+                start: '3K',
+				end: '50K',
+		}),
+    template: '<base-range-input :subProps="{ rangeLabels }"/>',
+	}))	
 
 storiesOf('Range Components/DynamicRangeSlider', module)
 	.addParameters({

--- a/stories/index.js
+++ b/stories/index.js
@@ -115,7 +115,7 @@ const showClear = (value = true) => getKnob('showClear', value);
 const highlight = (value = true) => getKnob('highlight', value);
 const showCheckbox = (value = true) => getKnob('showCheckbox', value);
 const rangeLabels = (value) => getKnob('rangeLabels', value);
-const showTooltip = (value) => getKnob('showTooltip', value, select);
+const showTooltip = (value) => getKnob('showTooltip', value, select, false);
 
 function removeFirstLine(str, number = 12) {
   while (number--) {
@@ -291,6 +291,16 @@ storiesOf('Range Components/DynamicRangeSlider', module)
 		components: { BaseDynamicRangeSlider },
 		template: '<base-dynamic-range-slider :subProps="{ defaultValue: function(min, max){ return { start: min + 1000, end: max - 1000} }, showFilter: false}"/>',
 	}))
+   .add('without tooltip', () => ({
+	components: { BaseDynamicRangeSlider },
+	   props: showTooltip(
+		   {
+                false: 'none',
+				true: 'always',
+				
+		}),
+    template: '<base-dynamic-range-slider :subProps="{ sliderOptions: { tooltip: showTooltip } }"/>',
+	}))			
 
 storiesOf('List Components/SingleList', module)
 	.addParameters({

--- a/stories/index.js
+++ b/stories/index.js
@@ -30,6 +30,7 @@ import SingleListWithRenderItemSlot from './SingleListWithRenderItemSlot.vue';
 import MultiListWithRenderSlot from './MultiListWithRenderSlot';
 import MultiListWithRenderItemSlot from './MultiListWithRenderItemSlot.vue';
 import SingleDropdownListWithRenderSlot from './SingleDropdownListWithRenderSlot';
+import SingleDropdownListWithRenderItemSlot from './SingleDropdownListWithRenderItemSlot.vue';
 import MultiDropdownListWithRenderSlot from './MultiDropdownListWithRenderSlot';
 import MultiDropdownListWithRenderItemSlot from './MultiDropdownListWithRenderItemSlot.vue';
 import DataSearchWithRenderQuerySuggestionsSlot from './DataSearchWithRenderQuerySuggestionsSlot';
@@ -472,8 +473,10 @@ storiesOf('List Components/SingleDropdownList', module)
     	components: { BaseSingleDropdownList },
     	template: '<base-single-dropdown-list :subProps="{ showClear, showSearch: true}"/>',
 	}))
-
-
+	.add('with renderItem slot', () => ({
+		components: { SingleDropdownListWithRenderItemSlot },
+		template: '<single-dropdown-list-with-render-item-slot />'
+	}))	
     .add('Playground', () => ({
 		components: { BaseSingleDropdownList },
 		props: Object.keys(

--- a/stories/index.js
+++ b/stories/index.js
@@ -31,6 +31,7 @@ import MultiListWithRenderSlot from './MultiListWithRenderSlot';
 import MultiListWithRenderItemSlot from './MultiListWithRenderItemSlot.vue';
 import SingleDropdownListWithRenderSlot from './SingleDropdownListWithRenderSlot';
 import MultiDropdownListWithRenderSlot from './MultiDropdownListWithRenderSlot';
+import MultiDropdownListWithRenderItemSlot from './MultiDropdownListWithRenderItemSlot.vue';
 import DataSearchWithRenderQuerySuggestionsSlot from './DataSearchWithRenderQuerySuggestionsSlot';
 import SingleListWithRenderNoResultsSlot from "./SingleListWithRenderNoResultsSlot.vue";
 import SingleDropdownListWithRenderNoResultsSlot from "./SingleDropdownListWithRenderNoResultsSlot";
@@ -590,6 +591,10 @@ storiesOf('List Components/MultiDropdownList ', module)
 		components: { MultiDropdownListWithRenderSlot },
 		template: '<multi-dropdown-list-with-render-slot />'
 	}))
+	.add('with renderItem slot', () => ({
+		components: { MultiDropdownListWithRenderItemSlot },
+		template: '<multi-dropdown-list-with-render-item-slot />'
+	}))	
 	.add('with renderNoResults', () => ({
 		components: { MultiDropdownListWithRenderNoResultsSlot },
 		template: '<multi-dropdown-list-with-render-no-results-slot />'

--- a/stories/index.js
+++ b/stories/index.js
@@ -46,6 +46,7 @@ import DataSearchWithAddonBeforeSlot from './DataSearchWithAddonBeforeSlot.vue';
 import DataSearchWithAddonAfterSlot from './DataSearchWithAddonAfterSlot.vue';
 import DataSearchWithAddonBeforeAfterSlots from './DataSearchWithAddonBeforeAfterSlots.vue';
 import BaseRangeInput from './BaseRangeInput.vue';
+import ReactiveListWithNoResultsSlot from './ReactiveListWithNoResultsSlot.vue';
 import './styles.css';
 
 // List Components
@@ -807,59 +808,63 @@ storiesOf('Result Components/Reactive List', module)
 			sidebar: removeFirstLine(ReactiveListReadme),
 		},
 	})
-  .addDecorator(withKnobs)
-  .add('Basic', () => ({
-    components: { BaseReactiveList },
-    template: '<base-reactive-list/>',
-  }))
-  .add('With pagination', () => ({
+	.addDecorator(withKnobs)
+	.add('Basic', () => ({
+		components: { BaseReactiveList },
+		template: '<base-reactive-list/>',
+	}))
+	.add('With pagination', () => ({
 		components: { BaseReactiveList },
 		props: getKnob('pagination', true),
-    template: '<base-reactive-list :subProps="{ pagination }"/>',
-  }))
-  .add('With Infinite Loading', () => ({
-    components: { BaseReactiveList },
-    template: '<base-reactive-list/>',
-  }))
-  .add('with custom sort', () => ({
+		template: '<base-reactive-list :subProps="{ pagination }"/>',
+	}))
+	.add('With Infinite Loading', () => ({
+		components: { BaseReactiveList },
+		template: '<base-reactive-list/>',
+	}))
+	.add('with custom sort', () => ({
 		components: { BaseReactiveList },
 		props: sortBy({ ascending: 'asc', descending: 'desc' }, 'asc'),
-    template: '<base-reactive-list :subProps="{ sortBy }"/>',
-  }))
-  .add('With pagination at top', () => ({
+		template: '<base-reactive-list :subProps="{ sortBy }"/>',
+	}))
+	.add('With pagination at top', () => ({
 		components: { BaseReactiveList },
 		props: paginationAt(),
-    template: '<base-reactive-list :subProps="{ pagination: true, paginationAt }"/>',
-  }))
-  .add('Without resultStats', () => ({
+		template: '<base-reactive-list :subProps="{ pagination: true, paginationAt }"/>',
+	}))
+	.add('Without resultStats', () => ({
 		components: { BaseReactiveList },
 		props: getKnob('showResultStats', false),
-    template: '<base-reactive-list :subProps="{ showResultStats }"/>',
-  }))
-  .add('With custom number of pages', () => ({
+		template: '<base-reactive-list :subProps="{ showResultStats }"/>',
+	}))
+	.add('With custom number of pages', () => ({
 		components: { BaseReactiveList },
 		props: getKnob('currentPage', 10),
-    template: '<base-reactive-list :subProps="{ pagination: true, currentPage }"/>',
-  }))
-  .add('with distinctField prop', () => ({
-	components: { BaseReactiveList },
-	props: {
-		distinctField: {
-			default: text('distinctField', 'authors.keyword'),
+		template: '<base-reactive-list :subProps="{ pagination: true, currentPage }"/>',
+	}))
+	.add('with distinctField prop', () => ({
+		components: { BaseReactiveList },
+		props: {
+			distinctField: {
+				default: text('distinctField', 'authors.keyword'),
+			},
+			distinctFieldConfig: {
+				default: object('distinctFieldConfig', {
+					inner_hits: {
+						name: 'most_recent',
+						size: 5,
+						sort: [{ timestamp: 'asc' }],
+					},
+				}),
+			},
 		},
-		distinctFieldConfig: {
-			default: object('distinctFieldConfig', {
-				inner_hits:
-				{
-					name:'most_recent',
-					size:5,
-					sort:[{timestamp:'asc'}]
-				}
-			})
-		}
-	},
-	template: `<base-reactive-list :subProps="{ distinctField, size: 3, distinctFieldConfig }"/>`,
-}));
+		template: `<base-reactive-list :subProps="{ distinctField, size: 3, distinctFieldConfig }"/>`,
+	}))
+	.add('with renderNoResults prop', () => ({
+		components: { ReactiveListWithNoResultsSlot },
+		props: getKnob('renderNoResults', 'No Results Found!'),
+		template: `<reactive-list-with-no-results-slot :subProps="{ renderNoResults }"/>`,
+	}));
 storiesOf('Result Components/ResultList', module)
 	.addParameters({
 		readme: {

--- a/stories/index.js
+++ b/stories/index.js
@@ -27,6 +27,7 @@ import BaseToggleButton from './BaseToggleButton.vue';
 import DataSearchWithRenderSlot from './DataSearchWithRenderSlot';
 import SingleListWithRenderSlot from './SingleListWithRenderSlot';
 import MultiListWithRenderSlot from './MultiListWithRenderSlot';
+import MultiListWithRenderItemSlot from './MultiListWithRenderItemSlot.vue';
 import SingleDropdownListWithRenderSlot from './SingleDropdownListWithRenderSlot';
 import MultiDropdownListWithRenderSlot from './MultiDropdownListWithRenderSlot';
 import DataSearchWithRenderQuerySuggestionsSlot from './DataSearchWithRenderQuerySuggestionsSlot';
@@ -388,6 +389,10 @@ storiesOf('List Components/MulitList', module)
 	components: { MultiListWithRenderSlot },
 	template: '<multi-list-with-render-slot />'
   }))
+  .add('with renderItem slot', () => ({
+    components: { MultiListWithRenderItemSlot },
+    template: '<multi-list-with-render-item-slot />',
+  }))	
   .add('with renderNoResults', () => ({
 	components: { MultiListWithRenderNoResultsSlot },
 	template: '<multi-list-with-render-no-results-slot />'

--- a/stories/index.js
+++ b/stories/index.js
@@ -26,6 +26,7 @@ import BaseResultCard from './BaseResultCard.vue';
 import BaseToggleButton from './BaseToggleButton.vue';
 import DataSearchWithRenderSlot from './DataSearchWithRenderSlot';
 import SingleListWithRenderSlot from './SingleListWithRenderSlot';
+import SingleListWithRenderItemSlot from './SingleListWithRenderItemSlot.vue';
 import MultiListWithRenderSlot from './MultiListWithRenderSlot';
 import MultiListWithRenderItemSlot from './MultiListWithRenderItemSlot.vue';
 import SingleDropdownListWithRenderSlot from './SingleDropdownListWithRenderSlot';
@@ -313,6 +314,10 @@ storiesOf('List Components/SingleList', module)
 	components: { SingleListWithRenderSlot },
 	template: '<single-list-with-render-slot />'
   }))
+  .add('with renderItem slot', () => ({
+	components: { SingleListWithRenderItemSlot },
+	template: '<single-list-with-render-item-slot />'
+  }))	
   .add('with renderNoResults', () => ({
 	components: { SingleListWithRenderNoResultsSlot },
 	template: '<single-list-with-render-no-results-slot />'

--- a/stories/index.js
+++ b/stories/index.js
@@ -108,6 +108,7 @@ const dataField = (value = ['original_series.keyword', 'authors.keyword', 'langu
 const paginationAt = (value = ['top', 'bottom', 'both'], defaultValue = 'bottom') => getKnob('paginationAt', value, select, defaultValue);
 const selectAllLabel = (value) => getKnob('selectAllLabel', value);
 const showCount = (value = true) => getKnob('showCount', value);
+const showSearch = (value = true) => getKnob('showSearch', value);
 const showClear = (value = true) => getKnob('showClear', value);
 const highlight = (value = true) => getKnob('highlight', value);
 const showCheckbox = (value = true) => getKnob('showCheckbox', value);
@@ -536,14 +537,17 @@ storiesOf('List Components/MultiDropdownList ', module)
 		components: { BaseMultiDropdownList },
 		props: showCount(false),
     template: '<base-multi-dropdown-list :subProps="{ showCount, showFilter: false}"/>',
-  }))
-
+  	}))
+    .add('with search', () => ({
+		components: { BaseMultiDropdownList },
+		props: showSearch(true),
+    template: '<base-multi-dropdown-list :subProps="{ showSearch, showFilter: false}"/>',
+  	}))
     .add('With Select All', () => ({
 		components: { BaseMultiDropdownList },
 		props: selectAllLabel('All Books'),
     template: '<base-multi-dropdown-list :subProps="{ selectAllLabel, showFilter: false}"/>',
-  }))
-
+  	}))
     .add('with defaultValue', () => ({
     components: { BaseMultiDropdownList },
 		props: defaultValue([

--- a/stories/index.js
+++ b/stories/index.js
@@ -47,6 +47,7 @@ import DataSearchWithAddonAfterSlot from './DataSearchWithAddonAfterSlot.vue';
 import DataSearchWithAddonBeforeAfterSlots from './DataSearchWithAddonBeforeAfterSlots.vue';
 import BaseRangeInput from './BaseRangeInput.vue';
 import ReactiveListWithNoResultsSlot from './ReactiveListWithNoResultsSlot.vue';
+import ReactiveListWithCustomResultStatsSlot from './ReactiveListWithCustomResultStatsSlot.vue';
 import './styles.css';
 
 // List Components
@@ -864,7 +865,13 @@ storiesOf('Result Components/Reactive List', module)
 		components: { ReactiveListWithNoResultsSlot },
 		props: getKnob('renderNoResults', 'No Results Found!'),
 		template: `<reactive-list-with-no-results-slot :subProps="{ renderNoResults }"/>`,
+	}))
+	.add('With custom result stats message', () => ({
+		components: { ReactiveListWithCustomResultStatsSlot },
+		template: '<reactive-list-with-custom-result-stats-slot />',
 	}));
+
+
 storiesOf('Result Components/ResultList', module)
 	.addParameters({
 		readme: {
@@ -899,8 +906,8 @@ storiesOf('Result Components/ResultList', module)
 	.add('With custom number of pages', () => ({
 		components: { BaseResultList },
 		props: getKnob('pages', 2),
-    template: '<base-result-list :subProps="{ pagination: true, pages }"/>',
-  }));
+		template: '<base-result-list :subProps="{ pagination: true, pages }"/>',
+	}));
 
 storiesOf('Result Components/ResultCard', module)
 	.addParameters({

--- a/stories/index.js
+++ b/stories/index.js
@@ -48,6 +48,7 @@ import DataSearchWithAddonBeforeAfterSlots from './DataSearchWithAddonBeforeAfte
 import BaseRangeInput from './BaseRangeInput.vue';
 import ReactiveListWithNoResultsSlot from './ReactiveListWithNoResultsSlot.vue';
 import ReactiveListWithCustomResultStatsSlot from './ReactiveListWithCustomResultStatsSlot.vue';
+import BaseReactiveListCardLayout from './BaseReactiveListCardLayout.vue';
 import './styles.css';
 
 // List Components
@@ -869,6 +870,10 @@ storiesOf('Result Components/Reactive List', module)
 	.add('With custom result stats message', () => ({
 		components: { ReactiveListWithCustomResultStatsSlot },
 		template: '<reactive-list-with-custom-result-stats-slot />',
+	}))
+	.add('With card layout', () => ({
+		components: { BaseReactiveListCardLayout },
+		template: '<base-reactive-list-card-layout />',
 	}));
 
 

--- a/stories/index.js
+++ b/stories/index.js
@@ -108,7 +108,7 @@ const showRadio = (value = true) => getKnob('showRadio', value);
 const sortBy = (value = { ascending: 'asc', descending: 'desc', count: 'count' }, defaultValue = 'asc') => getKnob('sortBy', value, select, defaultValue, String);
 const URLParams = (value = false) => getKnob('URLParams', value);
 const dataField = (value = ['original_series.keyword', 'authors.keyword', 'language_code.keyword'], defaultValue = 'original_series.keyword') => getKnob('dataField', value, select, defaultValue);
-const paginationAt = (value = ['top', 'bottom', 'both'], defaultValue = 'bottom') => getKnob('paginationAt', value, select, defaultValue);
+const paginationAt = (value = ['top', 'bottom', 'both'], defaultValue = 'top') => getKnob('paginationAt', value, select, defaultValue);
 const selectAllLabel = (value) => getKnob('selectAllLabel', value);
 const showCount = (value = true) => getKnob('showCount', value);
 const showSearch = (value = true) => getKnob('showSearch', value);

--- a/stories/index.js
+++ b/stories/index.js
@@ -115,6 +115,7 @@ const showClear = (value = true) => getKnob('showClear', value);
 const highlight = (value = true) => getKnob('highlight', value);
 const showCheckbox = (value = true) => getKnob('showCheckbox', value);
 const rangeLabels = (value) => getKnob('rangeLabels', value);
+const showTooltip = (value) => getKnob('showTooltip', value, select);
 
 function removeFirstLine(str, number = 12) {
   while (number--) {
@@ -228,6 +229,16 @@ storiesOf('Range Components/RangeSlider', module)
 		}),
     template: '<base-range-slider :subProps="{ rangeLabels }"/>',
 	}))	
+   .add('without tooltip', () => ({
+	components: { BaseRangeSlider },
+	   props: showTooltip(
+		   {
+                false: 'none',
+				true: 'always',
+				
+		}),
+    template: '<base-range-slider :subProps="{ sliderOptions: { tooltip: showTooltip } }"/>',
+	}))		
 
 storiesOf('Range Components/RangeInput', module)
 	.addParameters({

--- a/stories/index.js
+++ b/stories/index.js
@@ -457,7 +457,7 @@ storiesOf('List Components/SingleDropdownList', module)
     template: '<base-single-dropdown-list :subProps="{ showSearch, showFilter: false}"/>',
   }))  
     .add('with defaultValue', () => ({
-		props: defaultValue('Artemis Fowl'),
+		props: defaultValue('Discworld'),
     components: { BaseSingleDropdownList },
     template: '<base-single-dropdown-list :subProps="{ defaultValue, showFilter: false}"/>',
   }))


### PR DESCRIPTION
**PR Type** `Enhancement`

**Description** 
Added/ fixed missing/ broken stories as mentioned [here](https://www.notion.so/appbase/71e29cc1582b4bffb28e01b990c633ed?v=17701af672a8432e8c01ba9ff0b2c1b9).

- [x] MultiList: should render no results message.
- [x] MultiList: should use `renderItem` to render the list item.
- [x] SingleList: should render no results message.
- [x] SingleList: should use `renderItem` to render the list item.
- [x] MultiDropdownList: should render no results message.
- [x] MultiDropdownList: should not render search when `showSearch` is false.
- [x] MultiDropdownList:  should use `renderItem` to render the list item.
- [x] SingleDropdownList: should render no results message.
- [x] SingleDropdownList: should not render search when `showSearch` is false.
- [x] SingleDropdownList: should use `renderItem` to render the list item.
- [x] SingleDropdownList: should select default value.
- [x] RangeInput: should render range labels.
- [x] RangeSlider: should render range labels
- [x] RangeSlider: should not display tooltip when sliderOptions had tooltip as none
- [x] DynamicRangeSlider: should display tooltip
- [x] ReactiveList: should render items in a card layout 
- [x] ReactiveList: should render no results message
- [x] ReactiveList: should render pagination at top
- [x] ReactiveList: should render custom result stats message


[Loom  ](https://www.loom.com/share/c15ad735fa0a462aa5c112e701bfa33b)

